### PR TITLE
Changed text node's tagName to be parent element's

### DIFF
--- a/substitutions/js/substitutions.js
+++ b/substitutions/js/substitutions.js
@@ -37,7 +37,7 @@ chrome.runtime.sendMessage("config", function(response) {
                 "FORM": 0,
                 "TEXTAREA": 0
             };
-            if (node.tagName in ignore) {
+            if (node.parentElement.tagName in ignore) {
                 return;
             }
             for (i = replacementsObject.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Text nodes don't have a tag name -- it's undefined. Instead, we want to check the parent's tag name to see if we should ignore the text node. For example, if the text node is inside a &lt;script&gt;, its parent element will be the &lt;script&gt;, and we should skip this text node.